### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNCMaskedView.podspec
+++ b/RNCMaskedView.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-masked-view.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The latest Xcode 12 fails to build when a module does not depend on `React-Core` directly. This change is necessary for all native modules on iOS. For details please see: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
1. Build an App with Xcode 11.x. Result: The app builds.
2. Build an App with Xcode 12. Result: The app will not build when depending on `React`.
3. Build an App with Xcode 12 with the PR changes applied. Result: The app builds.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Mac OS with Xcode 12

### What are the steps to reproduce (after prerequisites)?
see Test Plan

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
